### PR TITLE
feat: github compare diff backend

### DIFF
--- a/querybook/webapp/components/DataDocGitHub/GitHub.scss
+++ b/querybook/webapp/components/DataDocGitHub/GitHub.scss
@@ -82,7 +82,7 @@
             flex-direction: column;
             height: 100%;
             background-color: var(--bg);
-            padding: 16px;
+            padding: 8px;
             box-sizing: border-box;
             overflow-y: auto;
         }

--- a/querybook/webapp/resource/github.ts
+++ b/querybook/webapp/resource/github.ts
@@ -46,4 +46,11 @@ export const GitHubResource = {
             limit,
             offset,
         }),
+    compareDataDocVersions: (docId: number, commitSha: string) =>
+        ds.fetch<{
+            current_content: string;
+            commit_content: string;
+        }>(`/github/datadocs/${docId}/compare/`, {
+            commit_sha: commitSha,
+        }),
 };


### PR DESCRIPTION
## Context 
- Backend for users to compare commit diffs

## Changes
- Strip metadata from current datadoc and selected datadoc commit to improve readability and use Query comparison for a side by side preview of diff. Display format below:

```
<DataDoc title>

## Query Cell: <Query Title>

<Query Cell Content>

## Text Cell:

<Text Cell Content>

## Chart Cell

<Placeholder Text (Chart generated from metadata)>
```



## Test Plan
Demo:

![image](https://github.com/user-attachments/assets/4e2c022e-47a8-47d4-a8ad-34639f9e94ba)


