### PR TITLE
feat: Add github datadoc restore feature

### DIFF
--- a/querybook/server/datasources_socketio/datadoc.py
+++ b/querybook/server/datasources_socketio/datadoc.py
@@ -216,6 +216,17 @@ def update_data_doc(id, fields):
     datadoc_collab.update_datadoc(id, fields, sid=request.sid)
 
 
+@register_socket("restore_data_doc", namespace=DATA_DOC_NAMESPACE)
+@data_doc_socket
+def restore_data_doc(datadoc_id: int, commit_sha: str, commit_message: str):
+    datadoc_collab.restore_data_doc(
+        datadoc_id=datadoc_id,
+        commit_sha=commit_sha,
+        commit_message=commit_message,
+        sid=request.sid,
+    )
+
+
 @register_socket("update_data_cell", namespace=DATA_DOC_NAMESPACE)
 @data_doc_socket
 def update_data_cell(doc_id, cell_id, fields):

--- a/querybook/server/lib/github/serializers.py
+++ b/querybook/server/lib/github/serializers.py
@@ -223,7 +223,7 @@ def deserialize_datadoc_content(content_str: str) -> List[DataCell]:
         cell = DataCell(
             id=metadata.get("id"),
             cell_type=cell_type_enum,
-            context=context if cell_type_enum != DataCellType.chart else None,
+            context=context if cell_type_enum != DataCellType.chart else "",
             created_at=parse_datetime_as_utc(metadata.get("created_at")),
             updated_at=parse_datetime_as_utc(metadata.get("updated_at")),
             meta=metadata.get("meta", {}),

--- a/querybook/webapp/components/DataDocGitHub/CommitCard.tsx
+++ b/querybook/webapp/components/DataDocGitHub/CommitCard.tsx
@@ -11,8 +11,8 @@ import './GitHub.scss';
 
 interface IProps {
     version: ICommit;
-    onRestore: (sha: string, message: string) => void;
-    onCompare: (version: ICommit) => void;
+    onRestore: (version: ICommit) => Promise<void>;
+    onCompare: (version?: ICommit) => void;
 }
 
 export const CommitCard: React.FC<IProps> = ({
@@ -41,9 +41,7 @@ export const CommitCard: React.FC<IProps> = ({
                 </Link>
             </Button>
             <AsyncButton
-                onClick={async () =>
-                    onRestore(version.sha, version.commit.message)
-                }
+                onClick={() => onRestore(version)}
                 className="ml8"
                 title="Restore Version"
                 hoverColor="var(--color-accent-dark)"

--- a/querybook/webapp/components/DataDocGitHub/GitHubVersions.tsx
+++ b/querybook/webapp/components/DataDocGitHub/GitHubVersions.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 
 import { QueryComparison } from 'components/TranspileQueryModal/QueryComparison';
+import { useRestoreDataDoc } from 'hooks/dataDoc/useRestoreDataDoc';
 import { usePaginatedResource } from 'hooks/usePaginatedResource';
 import { useResource } from 'hooks/useResource';
 import { GitHubResource, ICommit } from 'resource/github';
@@ -62,11 +63,15 @@ export const GitHubVersions: React.FunctionComponent<IProps> = ({
         }
     );
 
+    const restoreDataDoc = useRestoreDataDoc();
+
     const handleRestore = useCallback(
-        async (commitSha: string, commitMessage: string) => {
-            alert('Restore feature not implemented yet');
+        async (commit: ICommit) => {
+            const commitId = commit.sha;
+            const commitMessage = commit.commit.message;
+            await restoreDataDoc(docId, commitId, commitMessage);
         },
-        []
+        [docId, restoreDataDoc]
     );
 
     const toggleCompare = useCallback(
@@ -135,7 +140,7 @@ export const GitHubVersions: React.FunctionComponent<IProps> = ({
                     key={version.sha}
                     version={version}
                     onRestore={handleRestore}
-                    onCompare={() => toggleCompare(version)}
+                    onCompare={toggleCompare}
                 />
             ))}
         </div>
@@ -197,8 +202,8 @@ export const GitHubVersions: React.FunctionComponent<IProps> = ({
                         />
                     ) : (
                         <QueryComparison
-                            fromQuery={comparisonData?.current_content}
-                            toQuery={comparisonData?.commit_content}
+                            fromQuery={comparisonData?.commit_content}
+                            toQuery={comparisonData?.current_content}
                             fromQueryTitle={`Commit: ${selectedCommit.commit.message}`}
                             toQueryTitle="Current DataDoc"
                         />

--- a/querybook/webapp/const/analytics.ts
+++ b/querybook/webapp/const/analytics.ts
@@ -120,6 +120,7 @@ export enum ElementType {
     // Github Integration
     GITHUB_CONNECT_BUTTON = 'GITHUB_CONNECT_BUTTON',
     GITHUB_LINK_BUTTON = 'GITHUB_LINK_BUTTON',
+    GITHUB_RESTORE_DATADOC_BUTTON = 'GITHUB_RESTORE_DATADOC_BUTTON',
 }
 
 export interface EventData {

--- a/querybook/webapp/hooks/dataDoc/useRestoreDataDoc.ts
+++ b/querybook/webapp/hooks/dataDoc/useRestoreDataDoc.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+import { useDispatch } from 'react-redux';
+
+import { ComponentType, ElementType } from 'const/analytics';
+import { trackClick } from 'lib/analytics';
+import { sendConfirm } from 'lib/querybookUI';
+import { restoreDataDoc } from 'redux/dataDoc/action';
+import { Dispatch } from 'redux/store/types';
+
+export function useRestoreDataDoc() {
+    const dispatch: Dispatch = useDispatch();
+
+    const handleConfirm = useCallback(
+        (docId: number, commitId: string, commitMessage: string) => () => {
+            trackClick({
+                component: ComponentType.GITHUB,
+                element: ElementType.GITHUB_RESTORE_DATADOC_BUTTON,
+            });
+
+            toast.promise(
+                dispatch(restoreDataDoc(docId, commitId, commitMessage)),
+                {
+                    loading: 'Restoring DataDoc...',
+                    success: 'DataDoc has been successfully restored!',
+                    error: 'Failed to restore DataDoc. Please try again.',
+                }
+            );
+        },
+        [dispatch]
+    );
+
+    return useCallback(
+        async (
+            docId: number,
+            commitId: string,
+            commitMessage: string
+        ): Promise<void> => {
+            sendConfirm({
+                header: 'Restore DataDoc?',
+                message:
+                    'You are about to restore this DataDoc to the selected commit. Restoring will overwrite your current work. Please ensure you have committed any ongoing changes before proceeding.',
+                onConfirm: handleConfirm(docId, commitId, commitMessage),
+                confirmColor: 'cancel',
+                cancelColor: 'default',
+                confirmText: 'Confirm Restore',
+                confirmIcon: 'AlertOctagon',
+            });
+        },
+        [handleConfirm]
+    );
+}

--- a/querybook/webapp/lib/data-doc/datadoc-socketio.ts
+++ b/querybook/webapp/lib/data-doc/datadoc-socketio.ts
@@ -26,6 +26,15 @@ export interface IDataDocSocketEvent {
         (rawDataDoc, isSameOrigin: boolean) => any
     >;
 
+    dataDocRestored?: IDataDocSocketEventPromise<
+        (
+            rawDataDoc: any,
+            commitMessage: string,
+            username: string,
+            isSameOrigin: boolean
+        ) => any
+    >;
+
     updateDataCell?: IDataDocSocketEventPromise<
         (rawDataCell, isSameOrigin: boolean) => any
     >;
@@ -158,6 +167,17 @@ export class DataDocSocket {
         this.socket.emit('update_data_doc', docId, fields);
         return this.makePromise<IDataDocSocketPromise<[rawDataDoc: any]>>(
             'updateDataDoc'
+        );
+    };
+
+    public restoreDataDoc = (
+        docId: number,
+        commitId: string,
+        commitMessage: string
+    ) => {
+        this.socket.emit('restore_data_doc', docId, commitId, commitMessage);
+        return this.makePromise<IDataDocSocketPromise<[rawDataDoc: any]>>(
+            'dataDocRestored'
         );
     };
 
@@ -319,6 +339,19 @@ export class DataDocSocket {
                     rawDataDoc
                 );
             });
+
+            this.socket.on(
+                'data_doc_restored',
+                (originator, rawDataDoc, commitMessage, username) => {
+                    this.resolvePromiseAndEvent(
+                        'dataDocRestored',
+                        originator,
+                        rawDataDoc,
+                        commitMessage,
+                        username
+                    );
+                }
+            );
 
             this.socket.on('data_cell_updated', (originator, rawDataCell) => {
                 this.resolvePromiseAndEvent(

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -273,6 +273,17 @@ export function deleteDataDoc(docId: number): ThunkResult<Promise<void>> {
     };
 }
 
+export function restoreDataDoc(
+    docId: number,
+    commitId: string,
+    commitMessage: string
+): ThunkResult<Promise<void>> {
+    return async (dispatch) => {
+        await dataDocSocket.restoreDataDoc(docId, commitId, commitMessage);
+        await dispatch(fetchDataDoc(docId));
+    };
+}
+
 export function insertDataDocCell(
     docId: number,
     index: number,

--- a/querybook/webapp/redux/dataDocWebsocket/dataDocWebsocket.ts
+++ b/querybook/webapp/redux/dataDocWebsocket/dataDocWebsocket.ts
@@ -1,3 +1,5 @@
+import toast from 'react-hot-toast';
+
 import { IAccessRequest } from 'const/accessRequest';
 import { IDataDocEditor } from 'const/datadoc';
 import dataDocSocket, {
@@ -61,6 +63,25 @@ export function openDataDoc(docId: number): ThunkResult<Promise<any>> {
                     }
                 },
             },
+
+            dataDocRestored: {
+                resolve: (
+                    rawDataDoc,
+                    commitMessage,
+                    username,
+                    isSameOrigin
+                ) => {
+                    dispatch(fetchDataDoc(docId));
+
+                    // Show a notification to other users
+                    if (!isSameOrigin) {
+                        toast.success(
+                            `DataDoc restored by ${username}: "${commitMessage}"`
+                        );
+                    }
+                },
+            },
+
             updateDataCell: {
                 resolve: (rawDataCell, isSameOrigin) => {
                     if (!isSameOrigin) {


### PR DESCRIPTION
## Context
Users can now restore previous versions of datadoc commit on github. 
Other subscribed clients will receive a notice their Datadoc was restored and dispatch action to fetch restored datadoc.

### E2E Flow:
[User clicks Restore button] 
     ↓
[Frontend Dispatches Action and  emits "restore_data_doc" Event]
     ↓
[Backend Receives Event via "restore_data_doc" socket]
     ↓
[Backend Executes Restoration Logic and updates mySql DB for DataDoc and DataCells]
     ↓
[Backend Emits "data_doc_restored" Event]
     ↓
[Frontend Receives "data_doc_restored" Event and dispatches FETCH_DATA_DOC Action]
     ↓
[Redux Store Updates State]

## Test Plan
Originator demo:

https://github.com/user-attachments/assets/dd0e9800-7d1e-49c9-8ff3-39a8bfc99063

Non Originator View: (Clients who did not initiate restore but subscribed to datadoc events)

https://github.com/user-attachments/assets/8b2ba066-d4fe-449e-aa2d-8a4fbf4d8611

