### PR TITLE
ui: Add reviewer view 

### DIFF
--- a/querybook/config/querybook_public_config.yaml
+++ b/querybook/config/querybook_public_config.yaml
@@ -46,18 +46,30 @@ github_integration:
     enabled: false
 
 peer_review:
-    enabled: false
-    request_texts: # When users request reviews
-        description: >-
-            Use this feature to ensure the accuracy and compliance of your sensitive queries,
-            such as those modifying production tables. Select trusted reviewers who will
-            verify your query before it is executed.
+    enabled: true
+    request_texts:  # When users request reviews
+        description: |
+            This peer review system helps ensure query quality and data safety.
+
+            Note: Queries that fail after approval will require a new review request.
+
+            Important Guidelines:
+            • Choose reviewers familiar with the affected data
+            • Include relevant references in query title or justification
+            • Document query purpose and impact
         guide_link: 'https://www.querybook.org/'
-        tip: >-
-            Tip: Before submitting your sensitive query for review, run it once to validate
-            its syntax and feasibility. This helps identify errors early and reduces
-            unnecessary review cycles.
-    reviewer_texts: # When reviewers take actions
-        approve_message: >-
-            By approving this query, you confirm it meets our organization's standards
-            and security requirements. This action cannot be undone.
+        tip: |
+            Before Submitting:
+            • Run query to verify syntax
+            • Validate table names and fields
+            • Check query performance
+    reviewer_texts:  # When reviewers take actions
+        approve_message: |
+            As a reviewer, you are responsible for validating:
+
+            • Query purpose and necessity
+            • Potential data impact
+            • Compliance with data policies
+
+            Request clarification if more context is needed.
+            Approval cannot be reversed.

--- a/querybook/config/querybook_public_config.yaml
+++ b/querybook/config/querybook_public_config.yaml
@@ -47,7 +47,7 @@ github_integration:
 
 peer_review:
     enabled: false
-    modal_texts: # Review request modal texts
+    request_texts: # When users request reviews
         description: >-
             Use this feature to ensure the accuracy and compliance of your sensitive queries,
             such as those modifying production tables. Select trusted reviewers who will
@@ -57,3 +57,7 @@ peer_review:
             Tip: Before submitting your sensitive query for review, run it once to validate
             its syntax and feasibility. This helps identify errors early and reduces
             unnecessary review cycles.
+    reviewer_texts: # When reviewers take actions
+        approve_message: >-
+            By approving this query, you confirm it meets our organization's standards
+            and security requirements. This action cannot be undone.

--- a/querybook/notification_templates/query_review_approved.md
+++ b/querybook/notification_templates/query_review_approved.md
@@ -1,0 +1,3 @@
+Your query review has been approved by {{ reviewer_name }} on {{ approved_at }}.
+
+**Here is the url to view the running query: <{{ query_execution_url }}>**

--- a/querybook/notification_templates/query_review_rejected.md
+++ b/querybook/notification_templates/query_review_rejected.md
@@ -1,0 +1,8 @@
+Your query review (Query ID: {{ query_execution_id }}) has been rejected by {{ reviewer_name }} on {{ rejected_at }}.
+
+**Rejection reason provided:**
+{{ rejection_reason }}
+
+**Here is the url to view the query: <{{ query_execution_url }}>**
+
+Please address the feedback and submit a new review request once changes are made.

--- a/querybook/notification_templates/query_review_request.md
+++ b/querybook/notification_templates/query_review_request.md
@@ -1,12 +1,9 @@
-🚨 Action Required: Query Review Request
+New Query Review Required: Request from {{ requested_by }}
 
-A query requires your review before execution. Please review the SQL changes to ensure they meet your organization's standards and requirements.
+Query review requested on {{ requested_at }}
 
-**Details:**
+**Request Reason:** {{ review_request_reason }}
 
--   Requested by: {{ requested_by }}
--   Submitted: {{ requested_at }}
--   Review URL: {{ query_execution_url }}
--   Reason for Review: {{ review_request_reason }}
+**Here is the url for review: <{{ query_execution_url }}>**
 
-Please review the query at your earliest convenience.
+Please review the query at your earliest convenience to ensure it meets standards and requirements.

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -758,23 +758,21 @@ def transpile_query(
 
 @register("/query_execution/<int:query_execution_id>/approve_review/", methods=["PUT"])
 def approve_query_review(query_execution_id):
-    with DBSession() as session:
-        verify_query_execution_permission(query_execution_id)
-        reviewer_id = current_user.id
+    verify_query_execution_permission(query_execution_id)
+    reviewer_id = current_user.id
 
-        query_execution = query_review_handler.approve_review(
-            query_execution_id, reviewer_id, session
-        )
-        return query_execution.to_dict(with_statement=False, with_query_review=True)
+    query_execution = query_review_handler.approve_review(
+        query_execution_id, reviewer_id
+    )
+    return query_execution.to_dict(with_statement=False, with_query_review=True)
 
 
 @register("/query_execution/<int:query_execution_id>/reject_review/", methods=["PUT"])
 def reject_query_review(query_execution_id, rejection_reason):
-    with DBSession() as session:
-        verify_query_execution_permission(query_execution_id)
-        reviewer_id = current_user.id
+    verify_query_execution_permission(query_execution_id)
+    reviewer_id = current_user.id
 
-        query_execution = query_review_handler.reject_review(
-            query_execution_id, reviewer_id, rejection_reason, session
-        )
-        return query_execution.to_dict(with_statement=False, with_query_review=True)
+    query_execution = query_review_handler.reject_review(
+        query_execution_id, reviewer_id, rejection_reason
+    )
+    return query_execution.to_dict(with_statement=False, with_query_review=True)

--- a/querybook/server/lib/query_review/utils.py
+++ b/querybook/server/lib/query_review/utils.py
@@ -1,24 +1,42 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+from datetime import datetime
 from app.db import with_session
 from env import QuerybookSettings
 from lib.notify.utils import notify_user
 from logic import query_review as logic, user as user_logic
 from logic.query_execution import get_environments_by_execution_id
+from models.query_execution import QueryExecution
+from models.query_review import QueryReview
 
 
-def get_query_execution_url(query_execution_id: int, session=None) -> str:
+def _format_timestamp(dt: datetime) -> str:
+    """Format datetime for notifications.
+
+    Args:
+        dt: Datetime to format
+    Returns:
+        str: Formatted timestamp string
     """
-    Constructs the query execution URL based on environment.
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_query_execution_url(query_execution_id: int, session=None) -> Optional[str]:
+    """Construct query execution URL.
+
+    Args:
+        query_execution_id: ID of query execution
+        session: Database session
+    Returns:
+        Optional[str]: Full URL or None if environment not found
     """
     execution_envs = get_environments_by_execution_id(
         query_execution_id, session=session
     )
-    env = execution_envs[0] if execution_envs else None
-    return (
-        f"{QuerybookSettings.PUBLIC_URL}/{env.name}/query_execution/{query_execution_id}/"
-        if env
-        else None
-    )
+    if not execution_envs:
+        return None
+
+    env = execution_envs[0]
+    return f"{QuerybookSettings.PUBLIC_URL}/{env.name}/query_execution/{query_execution_id}/"
 
 
 @with_session
@@ -28,10 +46,8 @@ def notify_reviewers_of_new_request(
     template_name: str,
     additional_params: Dict[str, Any],
     session=None,
-):
-    """
-    Notifies assigned reviewers of a new review request.
-    """
+) -> None:
+    """Notify reviewers about new review request."""
     query_review = logic.get_query_review(query_review_id, session=session)
     if not query_review:
         return
@@ -46,12 +62,11 @@ def notify_reviewers_of_new_request(
 
     template_params = {
         "requested_by": requested_by,
-        "requested_at": query_review.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+        "requested_at": _format_timestamp(query_review.created_at),
         "query_execution_url": execution_url,
         "review_request_reason": query_review.request_reason,
+        **additional_params,
     }
-    if additional_params:
-        template_params.update(additional_params)
 
     for reviewer in query_review.assigned_reviewers:
         notify_user(
@@ -60,3 +75,66 @@ def notify_reviewers_of_new_request(
             template_params=template_params,
             session=session,
         )
+
+
+@with_session
+def notify_query_author_of_rejection(
+    query_review: QueryReview,
+    query_execution: QueryExecution,
+    rejection_reason: str,
+    reviewer_id: int,
+    session=None,
+) -> None:
+    """Notify query author about rejection."""
+    reviewer = user_logic.get_user_by_id(reviewer_id, session=session)
+    reviewer_name = reviewer.get_name() if reviewer else "Reviewer"
+
+    execution_url = get_query_execution_url(
+        query_execution_id=query_execution.id,
+        session=session,
+    )
+
+    template_params = {
+        "reviewer_name": reviewer_name,
+        "query_execution_url": execution_url,
+        "rejection_reason": rejection_reason,
+        "query_execution_id": query_execution.id,
+        "rejected_at": _format_timestamp(query_review.updated_at),
+    }
+
+    notify_user(
+        user=query_execution.owner,
+        template_name="query_review_rejected",
+        template_params=template_params,
+        session=session,
+    )
+
+
+@with_session
+def notify_query_author_of_approval(
+    query_review: QueryReview,
+    query_execution: QueryExecution,
+    reviewer_id: int,
+    session=None,
+) -> None:
+    """Notify query author about approval."""
+    reviewer = user_logic.get_user_by_id(reviewer_id, session=session)
+    reviewer_name = reviewer.get_name() if reviewer else "Reviewer"
+
+    execution_url = get_query_execution_url(
+        query_execution_id=query_execution.id,
+        session=session,
+    )
+
+    template_params = {
+        "reviewer_name": reviewer_name,
+        "query_execution_url": execution_url,
+        "approved_at": _format_timestamp(query_review.updated_at),
+    }
+
+    notify_user(
+        user=query_execution.owner,
+        template_name="query_review_approved",
+        template_params=template_params,
+        session=session,
+    )

--- a/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
@@ -8,7 +8,6 @@ import { AdminAuditLogButton } from 'components/AdminAuditLog/AdminAuditLogButto
 import { IAdminMetastore, IAdminQueryEngine } from 'const/admin';
 import { QueryEngineStatus } from 'const/queryEngine';
 import { useResource } from 'hooks/useResource';
-import { PEER_REVIEW_CONFIG } from 'lib/public-config';
 import { sendConfirm } from 'lib/querybookUI';
 import history from 'lib/router-history';
 import { titleize } from 'lib/utils';
@@ -264,7 +263,7 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
         item: IAdminQueryEngine,
         onChange: (fieldName: string, fieldValue: any) => void
     ) => {
-        const { isEnabled: peerReviewEnabled } = usePeerReview();
+        const { isEnabled: isPeerReviewEnabled } = usePeerReview();
 
         const updateExecutor = (executor: string) => {
             onChange('executor', executor);
@@ -442,7 +441,7 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
                                     label="(Experimental) Enable Row Limit"
                                 />
 
-                                {peerReviewEnabled && (
+                                {isPeerReviewEnabled && (
                                     <SimpleField
                                         stacked
                                         name="feature_params.peer_review"

--- a/querybook/webapp/components/QueryPeerReviewModal/QueryPeerReviewModal.scss
+++ b/querybook/webapp/components/QueryPeerReviewModal/QueryPeerReviewModal.scss
@@ -1,0 +1,125 @@
+.QueryPeerReviewModal {
+    .flex-row {
+        width: 100%;
+
+        .Message {
+            width: 100%;
+        }
+    }
+
+    .description-section {
+        margin-bottom: 24px;
+
+        .Message {
+            padding: 0;
+            overflow: hidden;
+            border-radius: var(--border-radius);
+        }
+
+        .description-content {
+            display: grid;
+            grid-template-columns: 1.5fr 1fr;
+            min-height: 100%;
+
+            h4 {
+                font-size: var(--med-text-size);
+                font-weight: var(--bold-font);
+                color: var(--text-dark);
+                margin-bottom: 12px;
+                padding-bottom: 8px;
+                border-bottom: 1px solid var(--border);
+            }
+
+            .main-description {
+                padding: 20px;
+                background: var(--bg);
+
+                .description-text {
+                    color: var(--text);
+                    font-size: var(--text-size);
+                    line-height: 1.6;
+                    white-space: pre-wrap;
+
+                    ul {
+                        list-style-type: none;
+                        padding-left: 0;
+                        margin: 12px 0;
+
+                        li {
+                            position: relative;
+                            padding-left: 20px;
+                            margin-bottom: 8px;
+
+                            &:before {
+                                content: "•";
+                                position: absolute;
+                                left: 0;
+                                color: var(--color-accent);
+                            }
+                        }
+                    }
+                }
+            }
+
+            .checklist-box {
+                padding: 20px;
+                background: var(--color-accent-lightest-0);
+                border-left: 1px solid var(--border);
+
+                .checklist-content {
+                    color: var(--text);
+                    font-size: var(--text-size);
+                    line-height: 1.6;
+
+                    ul {
+                        list-style-type: none;
+                        padding-left: 0;
+                        margin: 12px 0;
+
+                        li {
+                            position: relative;
+                            padding-left: 20px;
+                            margin-bottom: 8px;
+
+                            &:before {
+                                content: "✓";
+                                position: absolute;
+                                left: 0;
+                                color: var(--color-true);
+                            }
+                        }
+                    }
+                }
+
+                .guide-link {
+                    margin-top: 16px;
+                    padding-top: 16px;
+                    border-top: 1px solid var(--border);
+
+                    a {
+                        display: inline-flex;
+                        align-items: center;
+                        gap: 6px;
+                        color: var(--color-accent);
+                        font-size: var(--small-text-size);
+                        padding: 6px 12px;
+                        border-radius: var(--border-radius-sm);
+                        transition: background-color 0.2s ease;
+
+                        &:hover {
+                            background: var(--color-accent-lightest);
+                            text-decoration: none;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    .modal-footer-buttons {
+        display: flex;
+        justify-content: flex-end;
+        padding: 16px 0 0;
+        border-top: 1px solid var(--border);
+    }
+}

--- a/querybook/webapp/components/QueryPeerReviewModal/QueryPeerReviewModal.tsx
+++ b/querybook/webapp/components/QueryPeerReviewModal/QueryPeerReviewModal.tsx
@@ -13,6 +13,7 @@ import { Link } from 'ui/Link/Link';
 import { Message } from 'ui/Message/Message';
 import { Modal } from 'ui/Modal/Modal';
 import { IStandardModalProps } from 'ui/Modal/types';
+import { Icon } from 'ui/Icon/Icon';
 
 import './QueryPeerReviewModal.scss';
 import { usePeerReview } from 'lib/peer-review/config';
@@ -22,7 +23,40 @@ interface IQueryPeerReviewFormProps {
     onHide: () => void;
 }
 
-const QueryPeerReviewForm: React.FC<IQueryPeerReviewFormProps> = ({
+interface IDescriptionSectionProps {
+    description: string;
+    tip: string;
+    guideLink: string;
+}
+
+const DescriptionSection: React.FC<IDescriptionSectionProps> = ({
+    description,
+    tip,
+    guideLink,
+}) => (
+    <div className="description-section">
+        <Message type="info" size="large">
+            <div className="description-content">
+                <div className="main-description">
+                    <h4>About Peer Review</h4>
+                    <div className="description-text">{description}</div>
+                </div>
+
+                <div className="checklist-box">
+                    <h4>Review Checklist</h4>
+                    <div className="checklist-content">{tip}</div>
+                    <div className="guide-link">
+                        <Link to={guideLink} newTab>
+                            <Icon name="Book" size={12} />
+                            <span>View Complete Guidelines</span>
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        </Message>
+    </div>
+);
+export const QueryPeerReviewForm: React.FC<IQueryPeerReviewFormProps> = ({
     onSubmit,
     onHide,
 }) => {
@@ -78,29 +112,16 @@ const QueryPeerReviewForm: React.FC<IQueryPeerReviewFormProps> = ({
             {({ submitForm, isSubmitting, isValid, setFieldValue, values }) => (
                 <FormWrapper minLabelWidth="150px">
                     <Form>
-                        <div className="mb4 flex-row">
-                            <Message type="info" size="large">
-                                {description} Learn more{' '}
-                                <Link to={guideLink} newTab>
-                                    <strong>here</strong>.
-                                </Link>
-                            </Message>
-                        </div>
-                        {reviewTip && (
-                            <Message
-                                className="mb12"
-                                type="warning"
-                                size="small"
-                                message={reviewTip}
-                            />
-                        )}
+                        <DescriptionSection
+                            description={description}
+                            tip={reviewTip}
+                            guideLink={guideLink}
+                        />
 
                         <FormField
                             label="Reviewers"
                             stacked
-                            help={
-                                'Ensure selected reviewers have sufficient context to review the query'
-                            }
+                            help="Ensure selected reviewers have sufficient context to review the query"
                             required
                         >
                             <MultiCreatableUserSelect
@@ -124,13 +145,11 @@ const QueryPeerReviewForm: React.FC<IQueryPeerReviewFormProps> = ({
                             placeholder="Provide a justification."
                             rows={4}
                             stacked
-                            help={
-                                'Why do you need to run this sensitive query?'
-                            }
+                            help="Why do you need to run this sensitive query?"
                             required
                         />
 
-                        <div className="center-align mt16">
+                        <div className="modal-footer-buttons">
                             <AsyncButton
                                 onClick={submitForm}
                                 disabled={!isValid || isSubmitting}
@@ -152,7 +171,7 @@ export const QueryPeerReviewModal: React.FC<
     <Modal
         {...modalProps}
         onHide={onHide}
-        title="Request a peer review for your query"
+        title="Request a Peer Review for Your Query"
         className="QueryPeerReviewModal"
     >
         <QueryPeerReviewForm onSubmit={onSubmit} onHide={onHide} />

--- a/querybook/webapp/components/QueryPeerReviewModal/QueryPeerReviewModal.tsx
+++ b/querybook/webapp/components/QueryPeerReviewModal/QueryPeerReviewModal.tsx
@@ -41,9 +41,7 @@ const QueryPeerReviewForm: React.FC<IQueryPeerReviewFormProps> = ({
     });
 
     const {
-        texts: {
-            modal: { description, guideLink, reviewTip },
-        },
+        requestTexts: { description, guideLink, reviewTip },
     } = usePeerReview();
 
     const handleSubmit = useCallback(

--- a/querybook/webapp/components/QueryReviewsNavigator/QueryReviewButton.tsx
+++ b/querybook/webapp/components/QueryReviewsNavigator/QueryReviewButton.tsx
@@ -38,9 +38,10 @@ export const QueryReviewButton = React.memo<IQueryReviewButtonProps>(
         const { pendingReviews } = useAssignedReviews();
 
         const buttonTitle = pendingReviews.length
-            ? `You have ${pendingReviews.length} pending reviews`
+            ? `You have ${pendingReviews.length} pending ${
+                  pendingReviews.length === 1 ? 'review' : 'reviews'
+              }`
             : 'No pending reviews';
-
         return (
             <span className="QueryReviewButton">
                 <IconButton

--- a/querybook/webapp/components/QueryReviewsNavigator/QueryReviewItem.tsx
+++ b/querybook/webapp/components/QueryReviewsNavigator/QueryReviewItem.tsx
@@ -5,7 +5,7 @@ import { IQueryReview } from 'const/queryExecution';
 import { Status } from 'const/queryStatus';
 import history from 'lib/router-history';
 import { generateFormattedDate } from 'lib/utils/datetime';
-import { getWithinEnvUrl } from 'lib/utils/query-string';
+import { navigateWithinEnv } from 'lib/utils/query-string';
 import { UrlContextMenu } from 'ui/ContextMenu/UrlContextMenu';
 import { ShowMoreText } from 'ui/ShowMoreText/ShowMoreText';
 import { StatusIcon } from 'ui/StatusIcon/StatusIcon';
@@ -133,12 +133,12 @@ export const QueryReviewItem: React.FC<IQueryReviewItemProps> = ({
     const selfRef = useRef<HTMLDivElement>();
 
     const queryExecutionUrl = useMemo(
-        () => getWithinEnvUrl(`/query_execution/${review.query_execution_id}/`),
+        () => `/query_execution/${review.query_execution_id}/`,
         [review.query_execution_id]
     );
 
     const handleClick = useCallback(() => {
-        history.push(queryExecutionUrl, { isModal: true });
+        navigateWithinEnv(queryExecutionUrl);
     }, [queryExecutionUrl]);
 
     const statusColor: Status =

--- a/querybook/webapp/components/QueryReviewsNavigator/QueryReviewsNavigator.scss
+++ b/querybook/webapp/components/QueryReviewsNavigator/QueryReviewsNavigator.scss
@@ -10,10 +10,22 @@
         border-bottom: var(--border);
         background-color: var(--bg-lightest);
         padding: 8px 16px;
+        display: flex;
+        align-items: center;
 
         .list-header {
             background-color: transparent !important;
             margin: 0;
+        }
+
+        .Tabs {
+            flex: 1;
+            ul {
+                flex: 1;
+                li {
+                    flex: 1;
+                }
+            }
         }
     }
 
@@ -23,7 +35,7 @@
 
         .empty-section-message {
             text-align: center;
-            font-size: var(--xlarge-text-size);
+            font-size: var(--med-text-size);
             user-select: none;
             padding: 16px;
             font-weight: bold;

--- a/querybook/webapp/components/QueryView/QueryView.tsx
+++ b/querybook/webapp/components/QueryView/QueryView.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { AccessRequestButton } from 'components/AccessRequestButton/AccessRequestButton';
+import { QueryViewReview } from 'components/QueryViewReview/QueryViewReview';
+import { useQueryReview } from 'hooks/useQueryReview';
 import { formatError } from 'lib/utils/error';
 import * as queryExecutionsActions from 'redux/queryExecutions/action';
 import * as queryExecutionsSelector from 'redux/queryExecutions/selector';
@@ -23,6 +25,7 @@ export const QueryView: React.FunctionComponent<IProps> = ({ queryId }) => {
     const queryExecution = useSelector((state: IStoreState) =>
         queryExecutionsSelector.queryExecutionSelector(state, queryId)
     );
+    const queryReviewState = useQueryReview(queryExecution?.id);
 
     const handleQueryExecutionAccessRequest = React.useCallback(() => {
         dispatch(
@@ -43,7 +46,7 @@ export const QueryView: React.FunctionComponent<IProps> = ({ queryId }) => {
             return (
                 <ErrorPage
                     errorTitle="Access Denied"
-                    errorMessage="You do not have access to this query execution"
+                    errorMessage="You do not have access to this query execution."
                 >
                     <AccessRequestButton
                         onAccessRequest={handleQueryExecutionAccessRequest}
@@ -61,10 +64,16 @@ export const QueryView: React.FunctionComponent<IProps> = ({ queryId }) => {
                 item={queryExecution}
                 itemKey={queryId}
                 itemLoader={fetchQueryExecution}
-                errorRenderer={(error) => errorPage(error)}
+                errorRenderer={errorPage}
             >
                 <QueryViewEditor queryExecution={queryExecution} />
                 <QueryViewExecution queryExecution={queryExecution} />
+                {queryReviewState.review && (
+                    <QueryViewReview
+                        queryExecution={queryExecution}
+                        queryReviewState={queryReviewState}
+                    />
+                )}
             </Loader>
         </div>
     );

--- a/querybook/webapp/components/QueryViewReview/QueryViewReview.scss
+++ b/querybook/webapp/components/QueryViewReview/QueryViewReview.scss
@@ -1,0 +1,196 @@
+.QueryViewReview {
+    --review-spacing: 16px;
+    margin: 24px 0;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    transition: box-shadow 0.2s ease;
+
+    &:hover {
+        box-shadow: var(--shadow-mid);
+    }
+
+    .review-header {
+        padding: var(--review-spacing);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--bg-lightest);
+        border-bottom: 1px solid var(--border-light);
+    }
+
+    .header-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .review-content {
+        padding: var(--review-spacing);
+
+        .details-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 16px;
+        }
+
+        .detail-item {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 8px;
+
+            // Center UserBadge
+            &:first-child {
+                align-items: center;
+                text-align: center;
+            }
+
+            .request-reason {
+                width: 100%;
+                background: var(--bg-light);
+                padding: 12px;
+                border-radius: 6px;
+                line-height: 1.6;
+                font-size: 15px;
+                border: 1px solid var(--border-light);
+                color: var(--text);
+            }
+        }
+    }
+
+    .review-actions {
+        padding: var(--review-spacing);
+        border-top: 1px solid var(--border-light);
+        background: var(--bg-lightest);
+
+        .action-buttons {
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+    }
+
+    .reject-form-container {
+        padding: var(--review-spacing);
+
+        .reject-form {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+
+            textarea {
+                min-height: 120px;
+                width: 100%;
+                resize: vertical;
+            }
+
+            .form-buttons {
+                display: flex;
+                justify-content: flex-end;
+                gap: 8px;
+                margin-top: 8px;
+            }
+        }
+    }
+
+    .review-notifier,
+    .outcome-msg {
+        margin: 0;
+        border-radius: 0;
+        border-top: 1px solid var(--border-light);
+
+        &.error {
+            background-color: var(--bg-error-light);
+            border-left: 4px solid var(--color-error);
+        }
+    }
+
+    @media (max-width: 768px) {
+        .details-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .Modal {
+        .form-buttons {
+            margin-top: 16px;
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+    }
+
+    .rejection-details {
+        .rejection-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 12px;
+            background: var(--bg-lightest);
+            border-radius: 6px;
+            margin-bottom: 16px;
+            margin: 8px 0 16px;
+
+            .reviewer-info {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 12px;
+                background: var(--bg-lightest);
+                border-radius: 8px;
+            }
+        }
+
+        .rejection-reason {
+            background: var(--bg);
+            padding: 12px;
+            border-radius: 6px;
+            line-height: 1.6;
+            font-size: 15px;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            color: var(--text);
+            margin: 12px 0;
+            border: 1px solid var(--border-light);
+        }
+
+        .rejection-content {
+            padding: 16px;
+            background: var(--bg-light);
+            border-radius: 8px;
+            border: 1px solid var(--border-light);
+            transition: background-color 0.2s ease;
+
+            .rejection-reason {
+                margin: 12px 0;
+                padding: 12px;
+                background: var(--bg);
+                border-radius: 6px;
+                line-height: 1.6;
+                font-size: 15px;
+                white-space: pre-wrap;
+                word-wrap: break-word;
+                color: var(--text);
+            }
+
+            .rejection-note {
+                color: var(--text-light);
+                font-style: italic;
+            }
+        }
+    }
+
+    .rejection-title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 16px;
+        color: var(--text);
+    }
+}
+
+.Button:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}

--- a/querybook/webapp/components/QueryViewReview/QueryViewReview.tsx
+++ b/querybook/webapp/components/QueryViewReview/QueryViewReview.tsx
@@ -1,0 +1,369 @@
+import React, { useState, useCallback, memo } from 'react';
+import { useDispatch } from 'react-redux';
+import toast from 'react-hot-toast';
+import { Form, Formik } from 'formik';
+import * as Yup from 'yup';
+
+import { AccentText } from 'ui/StyledText/StyledText';
+import { Card } from 'ui/Card/Card';
+import { Button } from 'ui/Button/Button';
+import { SimpleField } from 'ui/FormikField/SimpleField';
+import { StatusIcon } from 'ui/StatusIcon/StatusIcon';
+import { Tag } from 'ui/Tag/Tag';
+import { Message } from 'ui/Message/Message';
+import { UserBadge } from 'components/UserBadge/UserBadge';
+import { Modal } from 'ui/Modal/Modal';
+
+import { IQueryExecution, IQueryReview } from 'const/queryExecution';
+import { Status } from 'const/queryStatus';
+import * as queryExecutionsActions from 'redux/queryExecutions/action';
+import { getStatusProps } from './statusUtils';
+import { generateFormattedDate } from 'lib/utils/datetime';
+import { ConfirmationMessage } from 'components/ConfirmationManager/ConfirmationMessage';
+import { Icon } from 'ui/Icon/Icon';
+
+import './QueryViewReview.scss';
+import { QueryReviewState } from 'hooks/useQueryReview';
+import { usePeerReview } from 'lib/peer-review/config';
+
+const rejectSchema = Yup.object().shape({
+    rejectionReason: Yup.string()
+        .required('Please provide a reason for rejecting this query')
+        .min(10, 'Rejection reason must be at least 10 characters'),
+});
+
+const ReviewHeader: React.FC<{
+    status: Status;
+    tooltip: string;
+    label: string;
+    tagClass: string;
+    tagText: string;
+}> = memo(({ status, tooltip, label, tagClass, tagText }) => (
+    <div className="review-header">
+        <div className="header-left">
+            <StatusIcon status={status} tooltip={tooltip} />
+            <AccentText weight="bold" className="header-label">
+                {label}
+            </AccentText>
+        </div>
+        <Tag
+            className={tagClass}
+            tooltip={tooltip}
+            tooltipPos="up"
+            color={
+                status === Status.success
+                    ? 'green'
+                    : status === Status.error
+                    ? 'red'
+                    : 'yellow'
+            }
+            withBorder
+        >
+            {tagText}
+        </Tag>
+    </div>
+));
+
+const ReviewContent: React.FC<{
+    review: IQueryReview;
+}> = memo(({ review }) => (
+    <div className="review-content">
+        <div className="details-grid">
+            <div className="detail-item">
+                <AccentText color="light" size="small">
+                    Requested By
+                </AccentText>
+                <UserBadge uid={review.requested_by} />
+            </div>
+            <div className="detail-item">
+                <AccentText color="light" size="small">
+                    Reason Provided by Author
+                </AccentText>
+                <AccentText className="request-reason">
+                    {review.request_reason || 'No reason provided'}
+                </AccentText>
+            </div>
+            <div className="detail-item">
+                <AccentText color="light" size="small">
+                    Review Requested At
+                </AccentText>
+                <AccentText className="request-reason">
+                    {generateFormattedDate(review.created_at)}
+                </AccentText>
+            </div>
+        </div>
+    </div>
+));
+
+const ReviewActions: React.FC<{
+    showRejectForm: boolean;
+    onShowRejectForm: (show: boolean) => void;
+    onApprove: () => void;
+    onReject: (values: { rejectionReason: string }) => void;
+}> = memo(({ showRejectForm, onShowRejectForm, onApprove, onReject }) => {
+    const [showApproveModal, setShowApproveModal] = useState(false);
+    const { reviewerTexts } = usePeerReview();
+
+    return (
+        <div className="review-actions">
+            <div className="action-buttons">
+                <Button
+                    title="Reject Query"
+                    color="cancel"
+                    onClick={() => onShowRejectForm(true)}
+                />
+                <Button
+                    title="Approve Query"
+                    color="confirm"
+                    onClick={() => setShowApproveModal(true)}
+                />
+            </div>
+
+            {showApproveModal && (
+                <ConfirmationMessage
+                    header="Confirm Query Approval"
+                    message={reviewerTexts.approveMessage}
+                    onConfirm={onApprove}
+                    onDismiss={() => setShowApproveModal(false)}
+                    onHide={() => setShowApproveModal(false)}
+                    confirmText="Approve"
+                    cancelText="Cancel"
+                    confirmColor="confirm"
+                    cancelColor="cancel"
+                    confirmIcon="Check"
+                    cancelIcon="X"
+                />
+            )}
+
+            {showRejectForm && (
+                <Modal
+                    title="Reject Query"
+                    onHide={() => onShowRejectForm(false)}
+                >
+                    <div className="reject-form-container">
+                        <Formik
+                            initialValues={{ rejectionReason: '' }}
+                            validationSchema={rejectSchema}
+                            onSubmit={onReject}
+                        >
+                            {({ submitForm }) => (
+                                <Form className="reject-form">
+                                    <SimpleField
+                                        name="rejectionReason"
+                                        label="Reason for Rejection"
+                                        help="Author must submit a new query review after addressing the rejection feedback."
+                                        type="textarea"
+                                        required
+                                    />
+                                    <div className="form-buttons">
+                                        <Button
+                                            title="Cancel"
+                                            onClick={() =>
+                                                onShowRejectForm(false)
+                                            }
+                                            className="mr8"
+                                            icon="X"
+                                            color="cancel"
+                                        />
+                                        <Button
+                                            title="Submit Rejection"
+                                            color="cancel"
+                                            onClick={submitForm}
+                                            icon="Send"
+                                        />
+                                    </div>
+                                </Form>
+                            )}
+                        </Formik>
+                    </div>
+                </Modal>
+            )}
+        </div>
+    );
+});
+
+const ReviewStatus: React.FC<{
+    isReviewer: boolean;
+    isPending: boolean;
+    isApproved: boolean;
+    isRejected: boolean;
+    queryReview: IQueryReview;
+    showRejectForm: boolean;
+    onShowRejectForm: (show: boolean) => void;
+    onApprove: () => void;
+    onReject: (values: { rejectionReason: string }) => void;
+}> = memo(
+    ({
+        isReviewer,
+        isPending,
+        isApproved,
+        isRejected,
+        queryReview,
+        showRejectForm,
+        onShowRejectForm,
+        onApprove,
+        onReject,
+    }) => {
+        if (!isReviewer && isPending) {
+            return (
+                <Message
+                    className="review-notifier"
+                    type="info"
+                    title="Review in Progress"
+                >
+                    This execution is currently under review. No further actions
+                    are required.
+                </Message>
+            );
+        }
+
+        if (isReviewer && isPending) {
+            return (
+                <ReviewActions
+                    showRejectForm={showRejectForm}
+                    onShowRejectForm={onShowRejectForm}
+                    onApprove={onApprove}
+                    onReject={onReject}
+                />
+            );
+        }
+
+        if (isApproved) {
+            return (
+                <Message
+                    className="outcome-msg"
+                    type="success"
+                    title="Approved"
+                >
+                    The query has been approved and is now executing.
+                </Message>
+            );
+        }
+
+        if (isRejected) {
+            return (
+                <Message
+                    className="outcome-msg"
+                    type="error"
+                    title={
+                        <div className="rejection-title">
+                            <Icon name="AlertCircle" size={20} />
+                            <span>Query Rejected</span>
+                        </div>
+                    }
+                >
+                    <div className="rejection-details">
+                        <div className="rejection-header">
+                            <div className="reviewer-info">
+                                <UserBadge uid={queryReview.reviewed_by} />
+                                <AccentText>
+                                    has reviewed and rejected this query
+                                </AccentText>
+                            </div>
+                        </div>
+                        <div className="rejection-content">
+                            <AccentText color="light" weight="bold">
+                                Rejection Reason:
+                            </AccentText>
+                            <AccentText className="rejection-reason">
+                                {queryReview.rejection_reason}
+                            </AccentText>
+                            <AccentText
+                                color="light"
+                                size="small"
+                                className="rejection-note"
+                            >
+                                Note: A new query review will need to be
+                                submitted after addressing these changes.
+                            </AccentText>
+                        </div>
+                    </div>
+                </Message>
+            );
+        }
+
+        return null;
+    }
+);
+
+export const QueryViewReview: React.FC<{
+    queryExecution: IQueryExecution;
+    queryReviewState: QueryReviewState;
+}> = memo(({ queryExecution, queryReviewState }) => {
+    const dispatch = useDispatch();
+    const {
+        permissions: { isReviewer },
+        status: { isPending, isRejected, isApproved },
+        review: queryReview,
+    } = queryReviewState;
+
+    const [showRejectForm, setShowRejectForm] = useState(false);
+
+    const handleApprove = useCallback(async () => {
+        try {
+            await dispatch(
+                queryExecutionsActions.approveQueryReview(queryExecution.id)
+            );
+            toast.success('Query approved successfully.');
+        } catch {
+            toast.error('Failed to approve the query.');
+        }
+    }, [dispatch, queryExecution.id]);
+
+    const handleReject = useCallback(
+        async (values: { rejectionReason: string }) => {
+            try {
+                await dispatch(
+                    queryExecutionsActions.rejectQueryReview(
+                        queryExecution.id,
+                        values.rejectionReason.trim()
+                    )
+                );
+                toast.success('Query rejected successfully.');
+            } catch {
+                toast.error('Failed to reject query.');
+            }
+        },
+        [dispatch, queryExecution.id]
+    );
+
+    if (!queryReview) {
+        return null;
+    }
+
+    const { status, tooltip, tagClass, tagText } = getStatusProps(
+        isApproved,
+        isRejected
+    );
+
+    return (
+        <Card
+            className="QueryViewReview"
+            flexRow={false}
+            alignLeft={true}
+            width="100%"
+        >
+            <ReviewHeader
+                status={status}
+                tooltip={tooltip}
+                label="Execution Review"
+                tagClass={tagClass}
+                tagText={tagText}
+            />
+
+            <ReviewContent review={queryReview} />
+
+            <ReviewStatus
+                isReviewer={isReviewer}
+                isPending={isPending}
+                isApproved={isApproved}
+                isRejected={isRejected}
+                queryReview={queryReview}
+                showRejectForm={showRejectForm}
+                onShowRejectForm={setShowRejectForm}
+                onApprove={handleApprove}
+                onReject={handleReject}
+            />
+        </Card>
+    );
+});

--- a/querybook/webapp/components/QueryViewReview/statusUtils.ts
+++ b/querybook/webapp/components/QueryViewReview/statusUtils.ts
@@ -1,0 +1,38 @@
+import { Status } from 'const/queryStatus';
+
+interface StatusProperties {
+    status: Status;
+    tooltip: string;
+    tagClass: string;
+    tagText: string;
+}
+
+export const getStatusProps = (
+    isApproved: boolean,
+    isRejected: boolean
+): StatusProperties => {
+    if (isApproved) {
+        return {
+            status: Status.success,
+            tooltip: 'Query has been approved.',
+            tagClass: 'Tag--success',
+            tagText: 'APPROVED',
+        };
+    }
+
+    if (isRejected) {
+        return {
+            status: Status.error,
+            tooltip: 'Changes have been requested.',
+            tagClass: 'Tag--error',
+            tagText: 'CHANGES REQUESTED',
+        };
+    }
+
+    return {
+        status: Status.warning,
+        tooltip: 'The query is pending review.',
+        tagClass: 'Tag--warning',
+        tagText: 'PENDING REVIEW',
+    };
+};

--- a/querybook/webapp/config.d.ts
+++ b/querybook/webapp/config.d.ts
@@ -135,12 +135,15 @@ declare module 'config/querybook_public_config.yaml' {
         };
         peer_review: {
             enabled: boolean;
-            texts: {
-                modal: {
-                    description: string;
-                    guide_link: string;
-                    tip: string;
-                };
+            request_texts: {
+                // When users request reviews
+                description: string;
+                guide_link: string;
+                tip: string;
+            };
+            reviewer_texts: {
+                // When reviewers take actions
+                approve_message: string;
             };
         };
     };

--- a/querybook/webapp/hooks/useQueryReview.ts
+++ b/querybook/webapp/hooks/useQueryReview.ts
@@ -1,0 +1,67 @@
+import { IQueryReview, QueryExecutionStatus } from 'const/queryExecution';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { IStoreState } from 'redux/store/types';
+import {
+    queryExecutionSelector,
+    queryReviewByExecutionIdSelector,
+} from 'redux/queryExecutions/selector';
+import { myUserInfoSelector } from 'redux/user/selector';
+
+export interface QueryReviewState {
+    status: {
+        isPending: boolean;
+        isRejected: boolean;
+        isApproved: boolean;
+    };
+    permissions: {
+        isReviewer: boolean;
+    };
+    review: IQueryReview | null;
+}
+
+const DEFAULT_REVIEW_STATE: QueryReviewState = {
+    status: {
+        isPending: false,
+        isRejected: false,
+        isApproved: false,
+    },
+    permissions: {
+        isReviewer: false,
+    },
+    review: null,
+};
+
+export function useQueryReview(executionId?: number): QueryReviewState {
+    const { queryExecution, currentUser, queryReview } = useSelector(
+        (state: IStoreState) => ({
+            queryExecution: executionId
+                ? queryExecutionSelector(state, executionId)
+                : null,
+            currentUser: myUserInfoSelector(state),
+            queryReview: executionId
+                ? queryReviewByExecutionIdSelector(state, executionId)
+                : null,
+        })
+    );
+
+    return useMemo(() => {
+        if (!executionId || !queryExecution || !queryReview) {
+            return DEFAULT_REVIEW_STATE;
+        }
+
+        const isPending =
+            queryExecution.status === QueryExecutionStatus.PENDING_REVIEW;
+        const isRejected =
+            queryExecution.status === QueryExecutionStatus.REJECTED;
+        const isApproved = !isPending && !isRejected;
+
+        return {
+            status: { isPending, isRejected, isApproved },
+            permissions: {
+                isReviewer: queryReview.reviewer_ids?.includes(currentUser.id),
+            },
+            review: queryReview,
+        };
+    }, [executionId, queryExecution, queryReview, currentUser]);
+}

--- a/querybook/webapp/lib/peer-review/config.ts
+++ b/querybook/webapp/lib/peer-review/config.ts
@@ -1,22 +1,30 @@
 import { useMemo } from 'react';
 import { PEER_REVIEW_CONFIG } from 'lib/public-config';
-import { IPeerReviewTexts } from './types';
 
 export interface IPeerReviewConfig {
     isEnabled: boolean;
-    texts: IPeerReviewTexts;
+    requestTexts: {
+        description: string;
+        guideLink: string;
+        reviewTip: string;
+    };
+    reviewerTexts: {
+        approveMessage: string;
+    };
 }
 
 export function usePeerReview(): IPeerReviewConfig {
     return useMemo(
         () => ({
             isEnabled: PEER_REVIEW_CONFIG.enabled,
-            texts: {
-                modal: {
-                    description: PEER_REVIEW_CONFIG.texts.modal.description,
-                    guideLink: PEER_REVIEW_CONFIG.texts.modal.guide_link,
-                    reviewTip: PEER_REVIEW_CONFIG.texts.modal.tip,
-                },
+            requestTexts: {
+                description: PEER_REVIEW_CONFIG.request_texts.description,
+                guideLink: PEER_REVIEW_CONFIG.request_texts.guide_link,
+                reviewTip: PEER_REVIEW_CONFIG.request_texts.tip,
+            },
+            reviewerTexts: {
+                approveMessage:
+                    PEER_REVIEW_CONFIG.reviewer_texts.approve_message,
             },
         }),
         []

--- a/querybook/webapp/lib/peer-review/types.ts
+++ b/querybook/webapp/lib/peer-review/types.ts
@@ -1,7 +1,0 @@
-export interface IPeerReviewTexts {
-    modal: {
-        description: string;
-        guideLink: string;
-        reviewTip: string;
-    };
-}

--- a/querybook/webapp/lib/public-config.ts
+++ b/querybook/webapp/lib/public-config.ts
@@ -40,11 +40,12 @@ export const getTableSamplingRateOptions = () => {
 
 export const PEER_REVIEW_CONFIG = PublicConfig.peer_review ?? {
     enabled: false,
-    texts: {
-        modal: {
-            description: '',
-            guide_link: '',
-            tip: '',
-        },
+    request_texts: {
+        description: '',
+        guide_link: '',
+        tip: '',
+    },
+    reviewer_texts: {
+        approve_message: '',
     },
 };

--- a/querybook/webapp/redux/queryExecutions/action.ts
+++ b/querybook/webapp/redux/queryExecutions/action.ts
@@ -35,12 +35,40 @@ import {
 } from './types';
 
 const statementExecutionSchema = new schema.Entity('statementExecution');
+const reviewSchema = new schema.Entity('review');
 const dataCellSchema = new schema.Entity('dataCell');
 const queryExecutionSchema = new schema.Entity('queryExecution', {
     statement_executions: [statementExecutionSchema],
     data_cell: dataCellSchema,
+    review: reviewSchema,
 });
 export const queryExecutionSchemaList = [queryExecutionSchema];
+
+export function approveQueryReview(
+    executionId: number
+): ThunkResult<Promise<IQueryExecution>> {
+    return async (dispatch) => {
+        const { data: execution } = await QueryExecutionResource.approveReview(
+            executionId
+        );
+        dispatch(receiveQueryExecution(execution));
+        return execution;
+    };
+}
+
+export function rejectQueryReview(
+    executionId: number,
+    rejectionReason: string
+): ThunkResult<Promise<IQueryExecution>> {
+    return async (dispatch) => {
+        const { data: execution } = await QueryExecutionResource.rejectReview(
+            executionId,
+            rejectionReason
+        );
+        dispatch(receiveQueryExecution(execution));
+        return execution;
+    };
+}
 
 export function addQueryExecutionAccessRequest(
     executionId: number
@@ -167,12 +195,15 @@ export function receiveQueryExecution(
     const {
         queryExecution: queryExecutionById = {},
         statementExecution: statementExecutionById = {},
+        review: queryReviewById = {},
     } = normalizedData.entities;
+
     return {
         type: '@@queryExecutions/RECEIVE_QUERY_EXECUTION',
         payload: {
             queryExecutionById,
             statementExecutionById,
+            queryReviewById,
             dataCellId,
         },
     };

--- a/querybook/webapp/redux/queryExecutions/reducer.ts
+++ b/querybook/webapp/redux/queryExecutions/reducer.ts
@@ -2,7 +2,7 @@ import { produce } from 'immer';
 import moment from 'moment';
 import { combineReducers } from 'redux';
 
-import { StatementExecutionStatus } from 'const/queryExecution';
+import { IQueryReview, StatementExecutionStatus } from 'const/queryExecution';
 import { arrayGroupByField, linkifyLog } from 'lib/utils';
 
 import { IQueryExecutionState, QueryExecutionAction } from './types';
@@ -10,6 +10,7 @@ import { IQueryExecutionState, QueryExecutionAction } from './types';
 const initialState: IQueryExecutionState = {
     queryExecutionById: {},
     statementExecutionById: {},
+    queryReviewByExecutionId: {},
 
     dataCellIdQueryExecution: {},
     queryExecutionIdToCellInfo: {},
@@ -184,6 +185,38 @@ function queryExecutionByIdReducer(
             }
         }
     });
+}
+
+function queryReviewByExecutionIdReducer(
+    state = initialState.queryReviewByExecutionId,
+    action: QueryExecutionAction
+) {
+    switch (action.type) {
+        case '@@queryExecutions/RECEIVE_QUERY_EXECUTION': {
+            const { queryReviewById } = action.payload;
+            if (queryReviewById) {
+                const queryReviewByExecutionId = {};
+
+                Object.values(queryReviewById).forEach(
+                    (queryReview: IQueryReview) => {
+                        if (queryReview) {
+                            queryReviewByExecutionId[
+                                queryReview.query_execution_id
+                            ] = queryReview;
+                        }
+                    }
+                );
+
+                return {
+                    ...state,
+                    ...queryReviewByExecutionId,
+                };
+            }
+            return state;
+        }
+        default:
+            return state;
+    }
 }
 
 function getPartialLogHeader() {
@@ -449,4 +482,5 @@ export default combineReducers({
     statementExporters: statementExportersReducer,
     accessRequestsByExecutionIdUserId: accessRequestsByExecutionIdUserIdReducer,
     viewersByExecutionIdUserId: viewersByExecutionIdUserIdReducer,
+    queryReviewByExecutionId: queryReviewByExecutionIdReducer,
 });

--- a/querybook/webapp/redux/queryExecutions/selector.ts
+++ b/querybook/webapp/redux/queryExecutions/selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { IQueryExecution } from 'const/queryExecution';
+import { IQueryExecution, IQueryReview } from 'const/queryExecution';
 import { IStoreState } from 'redux/store/types';
 
 const queryExecutionIdSetSelector = (state: IStoreState, cellId: number) =>
@@ -45,6 +45,16 @@ export const queryExecutionSelector = (
     state: IStoreState,
     executionId: number
 ) => state.queryExecutions.queryExecutionById[executionId] as IQueryExecution;
+
+export const queryReviewByExecutionIdSelector = (
+    state: IStoreState,
+    queryExecutionId: number | null
+): IQueryReview => {
+    if (queryExecutionId == null) {
+        return null;
+    }
+    return state.queryExecutions.queryReviewByExecutionId[queryExecutionId];
+};
 
 // returns array of query statement ids
 export const makeQueryExecutionStatementExecutionSelector = () =>

--- a/querybook/webapp/redux/queryExecutions/types.ts
+++ b/querybook/webapp/redux/queryExecutions/types.ts
@@ -7,6 +7,7 @@ import {
     IQueryExecution,
     IQueryExecutionViewer,
     IQueryResultExporter,
+    IQueryReview,
     IStatementExecution,
     IStatementLog,
     IStatementResult,
@@ -30,6 +31,7 @@ export interface IReceiveQueryExecutionAction extends Action {
     payload: {
         queryExecutionById: Record<number, IQueryExecution>;
         statementExecutionById: Record<number, IStatementExecution>;
+        queryReviewById: Record<number, IQueryReview>;
         dataCellId?: number;
     };
 }
@@ -186,6 +188,7 @@ export type QueryExecutionAction =
 export interface IQueryExecutionState {
     queryExecutionById: Record<number, IQueryExecution>;
     statementExecutionById: Record<number, IStatementExecution>;
+    queryReviewByExecutionId: Record<number, IQueryReview>;
 
     dataCellIdQueryExecution: Record<number, Set<number>>;
     queryExecutionIdToCellInfo: Record<

--- a/querybook/webapp/resource/queryExecution.ts
+++ b/querybook/webapp/resource/queryExecution.ts
@@ -99,6 +99,19 @@ export const QueryExecutionResource = {
 
     getError: (executionId: number) =>
         ds.fetch<IQueryError>(`/query_execution/${executionId}/error/`),
+
+    approveReview: (executionId: number) =>
+        ds.update<IRawQueryExecution>(
+            `/query_execution/${executionId}/approve_review/`
+        ),
+
+    rejectReview: (executionId: number, rejectionReason: string) =>
+        ds.update<IRawQueryExecution>(
+            `/query_execution/${executionId}/reject_review/`,
+            {
+                rejection_reason: rejectionReason,
+            }
+        ),
 };
 
 export const QueryExecutionMetadataResource = {


### PR DESCRIPTION
## Context
- Add reviewer view, where assigned reviewers can now approve/reject a query execution that is pending review.
- Scenarios:
   - Feature completely disabled in public config: we remove toggle in admin settings, and hide reviews icon on left side bar
   - Feature enabled but not used: We only show reviewer view on an execution if a review exists
   - Feature enabled and review requested: Show reviewer view with historical review context for approved/rejected queries, or approve/reject button for pending review queries

## Changes
- Reviewer UI
- Approve/Reject: endpoints, notifications, redux (fetch review along with query execution in QueryView.tsx)

## Test Plan

Demo:

https://github.com/user-attachments/assets/91f4f702-f1a2-4f5c-8ba8-c2757ba002ac

Assigned Reviewer:
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/017ecc8c-d2d4-48a5-94f1-a02a41c3ac44" />

Not Reviewer, Pending Review: 
![Screenshot 2025-01-24 at 7 24 51 PM](https://github.com/user-attachments/assets/9e091ecb-bf79-4b07-83d5-37d5b5376478)

Approved Review:
<img width="1321" alt="image" src="https://github.com/user-attachments/assets/755a1a70-3e14-43a5-ac76-d97693935530" />

Rejected Review:
<img width="1684" alt="image" src="https://github.com/user-attachments/assets/759783c2-8ae1-4d33-baf0-1d4401eaba50" />
